### PR TITLE
Simple name change

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,6 @@
-# The Official raywenderlich.com Swift Style Guide.
+# The Official Teamwork.com Swift Style Guide.  Forked from the original raywenderlich.com [style guide](https://github.com/raywenderlich/swift-style-guide)
 
-This style guide is different from others you may see, because the focus is centered on readability for print and the web. We created this style guide to keep the code in our books, tutorials, and starter kits nice and consistent — even though we have many different authors working on the books.
-
-Our overarching goals are conciseness, readability, and simplicity.
-
-Writing Objective-C? Check out our [Objective-C Style Guide](https://github.com/raywenderlich/objective-c-style-guide) too.
+Our overarching goals are conciseness, readability, and simplicity. 
 
 ## Table of Contents
 


### PR DESCRIPTION
to indicate that it's now the base document for Teamwork.com's own style guide.
